### PR TITLE
Disable manifest signing

### DIFF
--- a/Twinder.csproj
+++ b/Twinder.csproj
@@ -85,7 +85,7 @@
     <GenerateManifests>true</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="GalaSoft.MvvmLight, Version=5.3.0.19026, Culture=neutral, PublicKeyToken=e7570ab207bcb616, processorArchitecture=MSIL">


### PR DESCRIPTION
Disabling the option to sign the ClickOnce manifest for the project because
contributing developers do not have the signing key, so it causes the build
to fail.